### PR TITLE
Fix output when doing parallel deployments

### DIFF
--- a/code.json
+++ b/code.json
@@ -16,7 +16,7 @@
         "exemptionText": null
       },
       "vcs": "git",
-      "laborHours": 176,
+      "laborHours": 179,
       "tags": ["SBA", "DevOps", "AWS"],
       "contact": { "email": "Andrew.Davy@sba.gov" }
     }

--- a/exe/aws-cft
+++ b/exe/aws-cft
@@ -21,6 +21,7 @@ Clamp do
   option ['-T', '--tag'], 'NAME:VALUE', 'require a tag have the given value (may be given more than once)',
          multivalued: true
   option ['-v', '--[no-]verbose'], :flag, 'verbose narration of actions'
+  option ['-D', '--debug'], :flag, 'extra verbosity to aid in debugging'
   option '--version', :flag, 'Show version' do
     puts AwsCftTools::VERSION
     exit(0)
@@ -160,10 +161,16 @@ Clamp do
       profile: profile,
       root: root,
       region: region,
+      tags: tag_hash
+    }.merge(flag_options)
+  end
+
+  def flag_options
+    {
       noop: noop?,
       check: check?,
       verbose: verbose?,
-      tags: tag_hash
+      debug: debug?
     }
   end
 

--- a/lib/aws_cft_tools.rb
+++ b/lib/aws_cft_tools.rb
@@ -23,6 +23,7 @@ module AwsCftTools
   require 'aws_cft_tools/deletion_change'
   require 'aws_cft_tools/client'
   require 'aws_cft_tools/dependency_tree'
+  require 'aws_cft_tools/threaded_output'
   require 'aws_cft_tools/stack'
   require 'aws_cft_tools/template'
   require 'aws_cft_tools/template_set'

--- a/lib/aws_cft_tools/runbook.rb
+++ b/lib/aws_cft_tools/runbook.rb
@@ -48,6 +48,7 @@ module AwsCftTools
     def initialize(configuration = {})
       @options = configuration
       @client = AwsCftTools::Client.new(options)
+      @stdout = $stdout
     end
 
     # @!group Callbacks
@@ -135,6 +136,17 @@ module AwsCftTools
       else
         puts description
       end
+    end
+
+    ##
+    # @param note [String] a debug note
+    #
+    # Prints the given content to stdout if running in +debug+ mode. Debug statements are output
+    # without any capture when running multiple threads.
+    #
+    def debug(note = nil)
+      return unless note && options[:debug]
+      @stdout.puts "DEBUG\nDEBUG  " + note.split(/\n/).join("\nDEBUG  ") + "\nDEBUG"
     end
 
     ##

--- a/lib/aws_cft_tools/runbooks/common/changesets.rb
+++ b/lib/aws_cft_tools/runbooks/common/changesets.rb
@@ -19,6 +19,7 @@ module AwsCftTools
         # provide a tabular report of changeset actions
         #
         def narrate_changes(changes)
+          TablePrint::Config.io = $stdout
           tp(
             changes.map(&:to_narrative),
             %i[action logical_id physical_id type replacement scopes]

--- a/lib/aws_cft_tools/runbooks/deploy/threading.rb
+++ b/lib/aws_cft_tools/runbooks/deploy/threading.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'thread'
+
 module AwsCftTools
   module Runbooks
     class Deploy
@@ -9,27 +11,8 @@ module AwsCftTools
       module Threading
         private
 
-        # FIXME: things don't always work out well when capturing output
-        #        for now, we don't, and output gets mangled a bit when running with
-        #        multiple jobs in parallel
-        def with_captured_stdout(capture)
-          old_stdout = $stdout
-          old_table_io = TablePrint::Config.io
-          TablePrint::Config.io = $stdout = capture
-          yield
-        ensure
-          $stdout = old_stdout
-          TablePrint::Config.io = old_table_io
-        end
-
         def create_threads(list, &_block)
-          list.map { |item| threaded_process { yield item } }
-        end
-
-        def threaded_process(&block)
-          output = StringIO.new
-          thread = Thread.new { with_captured_stdout(output, &block) }
-          OpenStruct.new(output: output, thread: thread)
+          list.map { |item| Thread.new { yield item } }
         end
       end
     end

--- a/lib/aws_cft_tools/threaded_output.rb
+++ b/lib/aws_cft_tools/threaded_output.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+require 'thread'
+
+module AwsCftTools
+  ##
+  # Provides a way to process output and prefix with a thread identifier. The object is shared by
+  # threads. Each thread should set its own prefix.
+  #
+  class ThreadedOutput
+    extend Forwardable
+
+    #
+    # @param real_stdout [IO] The file object that should be written to with prefixed text.
+    #
+    def initialize(real_stdout)
+      @stdout = real_stdout
+      @buffer = Hash.new { |hash, key| hash[key] = '' }
+      @semaphore = Mutex.new
+    end
+
+    def_delegator :@semaphore, :synchronize, :guarded
+    def_delegators ThreadedOutput, :prefix
+
+    ##
+    # The prefix for output from the current thread.
+    #
+    def self.prefix
+      Thread.current['output_prefix'] || ''
+    end
+
+    ##
+    # @param prefix [String] The prefix for each line of text output by the calling thread.
+    #
+    def self.prefix=(prefix)
+      Thread.current['output_prefix'] = prefix + ': '
+    end
+
+    ##
+    # Ensure all buffered text is output. If any text is output, a newline is output as well.
+    #
+    def flush
+      guarded { @stdout.puts prefix + buffer } if buffer != ''
+      self.buffer = ''
+    end
+
+    ##
+    # Write the string to the output with prefixes as appropriate. If the string does not end in a
+    # newline, then the remaining text will be buffered until a newline is seen.
+    #
+    def write(string)
+      print(string)
+    end
+
+    ##
+    # Writes all of the arguments to the output with prefixes. Appends a newline to each argument.
+    #
+    # @param args [Array<String>]
+    #
+    def puts(*args)
+      print(args.join("\n") + "\n")
+    end
+
+    ##
+    # Writes all of the arugments to the output without newlines. Will output the prefix after each
+    # newline.
+    #
+    # @param args [Array<String>]
+    #
+    def print(*args)
+      append(args.join(''))
+      printable_lines.each do |line|
+        guarded { @stdout.puts prefix + line }
+      end
+    end
+
+    private
+
+    def printable_lines
+      lines = buffer.split(/\n/)
+      if buffer[-1..-1] == "\n"
+        self.buffer = ''
+      else
+        self.buffer = lines.last
+        lines = lines[0..-2]
+      end
+      lines
+    end
+
+    def buffer
+      @buffer[prefix]
+    end
+
+    def append(value)
+      @buffer[prefix] += value
+    end
+
+    def buffer=(string)
+      @buffer[prefix] = string
+    end
+  end
+end

--- a/spec/aws_cft_tools/threaded_output_spec.rb
+++ b/spec/aws_cft_tools/threaded_output_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'stringio'
+
+RSpec.describe AwsCftTools::ThreadedOutput do
+  let(:stringio) { StringIO.new }
+  let(:output) { described_class.new(stringio) }
+
+  describe 'prefix' do
+    let(:threaded_prefixes) do
+      prefixes = []
+      output # make sure output is created outside of the threads
+      threads = (1..2).map do |t|
+        Thread.new do
+          described_class.prefix = "thread-#{t}"
+          prefixes[t] = output.prefix
+        end
+      end
+      threads.map(&:join)
+      prefixes
+    end
+
+    it 'has different prefixes for different threads' do
+      expect(threaded_prefixes).to eq [nil, 'thread-1: ', 'thread-2: ']
+    end
+
+    it 'writes with a prefix' do
+      described_class.prefix = 'thread-prefix'
+      output.puts('This is a line')
+      expect(stringio.string).to eq "thread-prefix: This is a line\n"
+    end
+  end
+
+  describe 'write' do
+    before do
+      described_class.prefix = 'thread-prefix'
+    end
+
+    it "doesn't output until there's a newline" do
+      output.write('foo')
+      expect(stringio.string).to eq ''
+    end
+
+    it "writes when there's a newline" do
+      output.write("foo\nbar")
+      expect(stringio.string).to eq "thread-prefix: foo\n"
+    end
+  end
+
+  describe 'flush' do
+    before do
+      described_class.prefix = 'thread-prefix'
+    end
+
+    it "doesn't output if there's nothing in the buffer" do
+      output.flush
+      expect(stringio.string).to eq ''
+    end
+
+    it 'outputs whatever is left in the buffer' do
+      output.write('foo')
+      output.flush
+      expect(stringio.string).to eq "thread-prefix: foo\n"
+    end
+  end
+end


### PR DESCRIPTION
This should make threaded output more reliable. Running with `-j1` bypasses threads.

This should fix #7 .