### PR TITLE
Disregard undeployed templates when retracting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## UNRELEASED
+
+### Changed
+
+* When retracting stacks, a template that hadn't been deployed yet could block removal of any templates it
+  depended on. Now, retraction only considers templates that have been deployed. (Issue #18)
+
 ## [0.1.1] - 2017-12-15
 
 ### Added

--- a/lib/aws_cft_tools/dependency_tree.rb
+++ b/lib/aws_cft_tools/dependency_tree.rb
@@ -98,12 +98,25 @@ module AwsCftTools
     private
 
     def close_subset(set, &block)
-      return [] unless block_given?
-      set - items_outside_subset(set, &block)
+      find_all_available(set.to_a) { |all, acc| find_next_candidate(all, acc, &block) }
     end
 
-    def items_outside_subset(set)
-      set.select { |node| (yield(node) - set).any? }
+    def find_all_available(candidates)
+      available = []
+      while candidates.any?
+        candidate = yield(candidates, available)
+        return available unless candidate
+        available << candidate
+        candidates.delete(candidate)
+      end
+      available
+    end
+
+    def find_next_candidate(candidates, selected)
+      return unless block_given?
+      candidates.detect do |candidate|
+        (yield(candidate) - selected).empty?
+      end
     end
   end
 end

--- a/lib/aws_cft_tools/runbooks/retract.rb
+++ b/lib/aws_cft_tools/runbooks/retract.rb
@@ -55,7 +55,10 @@ module AwsCftTools
       # report_undefined_image - provide list of undefined imports that block stack deployment
       #
       def report_template_dependencies
-        diff = (templates - free_templates).map { |template| template.filename.to_s }
+        free = free_templates
+        deployed = client.stacks.map(&:name)
+        all = templates.select { |template| deployed.include?(template.name) }
+        diff = (all - free).map { |template| template.filename.to_s }
         error_on_dependencies(diff) if diff.any?
       end
 

--- a/lib/aws_cft_tools/runbooks/retract/templates.rb
+++ b/lib/aws_cft_tools/runbooks/retract/templates.rb
@@ -28,8 +28,11 @@ module AwsCftTools
         #
         # @return [AwsCftTools::TemplateSet]
         def free_templates
-          set = AwsCftTools::TemplateSet.new(templates.in_folder_order(template_folder_order))
-          client.templates.closed_subset(set).reverse
+          deployed = client.stacks.map(&:name)
+          universe = AwsCftTools::TemplateSet.new(client.templates.select do |template|
+            deployed.include?(template.name)
+          end)
+          universe.closed_subset(templates).reverse
         end
 
         ##

--- a/spec/aws_cft_tools/dependency_tree_spec.rb
+++ b/spec/aws_cft_tools/dependency_tree_spec.rb
@@ -44,16 +44,25 @@ RSpec.describe AwsCftTools::DependencyTree do
 
   describe '#closed_subset' do
     before do
-      tree.linked('A', 'B')
-      tree.linked('C', 'D')
+      { 'A' => %w[B C D E F G H J L],
+        'B' => %w[L I J K M],
+        'C' => %w[D F L M],
+        'D' => %w[G H L F],
+        'E' => %w[L M],
+        'F' => ['M'],
+        'G' => ['I'] }.each do |from, tos|
+        tos.each do |to|
+          tree.linked(from, to)
+        end
+      end
     end
 
     it 'returns the items with no downstream dependencies' do
-      expect(tree.closed_subset(%w[C B])).to eq ['B']
+      expect(tree.closed_subset(%w[D E F G H I J K L M]).sort).to eq %w[D E F G H I J K L M]
     end
 
     it 'returns the items that are interdependent but with no downstream dependencies' do
-      expect(tree.closed_subset(%w[D C B])).to eq %w[D C B]
+      expect(tree.closed_subset(%w[F G L M]).sort).to eq %w[F L M]
     end
   end
 end

--- a/spec/aws_cft_tools/runbooks/retract_spec.rb
+++ b/spec/aws_cft_tools/runbooks/retract_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe AwsCftTools::Runbooks::Retract do
                                        vpc_network_template
                                      ])
       end
-      
+
       let(:all_stacks) do
         [
           OpenStruct.new(name: vpc_base_template.name)

--- a/spec/aws_cft_tools/runbooks/retract_spec.rb
+++ b/spec/aws_cft_tools/runbooks/retract_spec.rb
@@ -82,8 +82,17 @@ RSpec.describe AwsCftTools::Runbooks::Retract do
                                    ])
     end
 
+    let(:all_stacks) do
+      all_templates.to_a.map do |template|
+        OpenStruct.new(
+          name: template.name
+        )
+      end
+    end
+
     before do
       allow(runbook).to receive(:deployed_filenames).and_return(['vpcs/base.yaml'])
+      allow(runbook.client).to receive(:stacks).and_return(all_stacks)
       allow(runbook.client).to receive(:templates).and_return(all_templates)
       allow(runbook.client).to receive(:images).and_return([])
       allow(runbook.client).to receive(:exports).and_return([])
@@ -163,7 +172,16 @@ RSpec.describe AwsCftTools::Runbooks::Retract do
   end
 
   describe '#free_templates' do
+    let(:all_stacks) do
+      all_templates.to_a.map do |template|
+        OpenStruct.new(
+          name: template.name
+        )
+      end
+    end
+
     before do
+      allow(runbook.client).to receive(:stacks).and_return(all_stacks)
       allow(runbook.client).to receive(:templates).and_return(all_templates)
     end
 
@@ -231,6 +249,25 @@ RSpec.describe AwsCftTools::Runbooks::Retract do
 
       it 'returns no templates in the set for removal' do
         expect(runbook.free_templates).to be_empty
+      end
+    end
+
+    describe 'with undeployed leaf templates' do
+      let(:all_templates) do
+        AwsCftTools::TemplateSet.new([
+                                       vpc_base_template,
+                                       vpc_network_template
+                                     ])
+      end
+      
+      let(:all_stacks) do
+        [
+          OpenStruct.new(name: vpc_base_template.name)
+        ]
+      end
+
+      it 'returns a template in the set for removal' do
+        expect(runbook.free_templates).to eq [vpc_base_template]
       end
     end
   end


### PR DESCRIPTION
Fixes #18 

If a template is marked as part of an environment or role, but hasn't been deployed, then it could cause another template that it depended on to be marked as having a dependency that would keep it from being deleted. Retract now only checks if there are deployed templates that depend on any templates that are candidates for removal.