### PR TITLE
Support AllowedPattern for environment matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## UNRELEASED
 
-### Changed
+### Added
 
-* Added support for `AllowedPattern` in the `Environment` template parameter.
+* Support for `AllowedPattern` in the `Environment` template parameter. (Issue #16)
 
-* Added support for parameter files to have environment names that resemble regular expressions. If the
-  parameter file doesn't have a key that matches the environment name exactly, then each of the top-level
-  keys in the file will be interpreted as a regular expression and matched against the environment being
-  deployed. The first match wins, so if multiple keys can match, then the result is undefined.
+* Support for parameter files to have environment names that resemble regular expressions. If the parameter
+  file doesn't have a key that matches the environment name exactly, then each of the top-level keys in the
+  file will be interpreted as a regular expression and matched against the environment being deployed. The
+  first match wins, so if multiple keys can match, then the result is undefined. (Issue #16)
 
 ## [0.1.2] - 2017-12-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## UNRELEASED
+
+### Changed
+
+* Added support for `AllowedPattern` in the `Environment` template parameter.
+
+* Added support for parameter files to have environment names that resemble regular expressions. If the
+  parameter file doesn't have a key that matches the environment name exactly, then each of the top-level
+  keys in the file will be interpreted as a regular expression and matched against the environment being
+  deployed. The first match wins, so if multiple keys can match, then the result is undefined.
+
 ## [0.1.2] - 2017-12-22
 
 ### Changed

--- a/lib/aws_cft_tools/template.rb
+++ b/lib/aws_cft_tools/template.rb
@@ -24,10 +24,10 @@ module AwsCftTools
   #
   # === Allowed Environments
   #
-  # The environments in which a template should be deployed is provided by the +AllowedValues+ key of the
-  # +Environment+ template parameter.
+  # The environments in which a template should be deployed is provided by the +AllowedValues+ or the
+  # +AllowedPattern+ key of the +Environment+ template parameter.
   #
-  # @example Allowed Environments
+  # @example Allowed Environments (explicit list)
   #   ---
   #   Parameters:
   #     Environment:
@@ -35,6 +35,12 @@ module AwsCftTools
   #         - QA
   #         - Staging
   #         - Production
+  #
+  # @example Allowed Environments (implicit pattern)
+  #   ---
+  #   Parameters:
+  #     Environment:
+  #       AllowedPattern: ^(QA|Staging|Production|Dev-.+)$
   #
   # === Allowed Regions
   #

--- a/lib/aws_cft_tools/template/metadata.rb
+++ b/lib/aws_cft_tools/template/metadata.rb
@@ -114,8 +114,14 @@ module AwsCftTools
       def parameters_for_filename_and_environment!(param_source, env)
         return { Environment: env } unless param_source
 
-        params = YAML.safe_load(process_erb_file(param_source), [], [], true)[env] || {}
-        params.update(Environment: env)
+        params_for_all = YAML.safe_load(process_erb_file(param_source), [], [], true)
+        return params_for_all[env].update('Environment' => env) if params_for_all.key?(env)
+
+        # now check for regex match on keys
+        params_for_all.each do |env_name, params|
+          return params.update('Environment' => env) if Regexp.compile("\\A#{env_name}\\Z").match?(env)
+        end
+        { 'Environment' => env }
       end
 
       def process_erb_file(content)

--- a/lib/aws_cft_tools/template/properties.rb
+++ b/lib/aws_cft_tools/template/properties.rb
@@ -15,8 +15,15 @@ module AwsCftTools
         template.dig('Parameters', 'Environment', 'AllowedValues') || []
       end
 
+      def allowed_environments_regex
+        source = template.dig('Parameters', 'Environment', 'AllowedPattern')
+        Regexp.compile(source) if source
+      end
+
       def environment?(value)
-        allowed_environments.include?(value)
+        return allowed_environments.include?(value) if allowed_environments.any?
+        regex = allowed_environments_regex
+        return regex.match?(value) if regex
       end
 
       ##

--- a/spec/aws_cft_tools/template_spec.rb
+++ b/spec/aws_cft_tools/template_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe AwsCftTools::Template do
       allow(FileTest).to receive(:exist?).with(parameter_path.to_path).and_return(true)
     end
 
-    describe 'in QA' do
+    describe 'in an environment that does not match a pattern and is explicitely named' do
       let(:env) { 'QA' }
 
       it 'has the right "Foo"' do
@@ -116,26 +116,34 @@ RSpec.describe AwsCftTools::Template do
       end
     end
 
-    describe 'in POC-one' do
+    describe 'in an environment that matches a pattern but is explicitely named' do
       let(:env) { 'POC-one' }
 
-      it 'has the right "Foo"' do
+      it 'has the right parameter value' do
         expect(params['Foo']).to eq 'one'
       end
-    end
 
-    describe 'in POC-supercalifragilistic' do
-      let(:env) { 'POC-supercalifragilistic' }
-
-      it 'has the right "Foo"' do
-        expect(params['Foo']).to eq 'any'
+      it 'has the right environment' do
+        expect(params['Environment']).to eq 'POC-one'
       end
     end
 
-    describe 'in undefined' do
+    describe 'in an environment matching on a pattern and not explicitely named' do
+      let(:env) { 'POC-supercalifragilistic' }
+
+      it 'has the right parameter value' do
+        expect(params['Foo']).to eq 'any'
+      end
+
+      it 'has the right environment' do
+        expect(params['Environment']).to eq 'POC-supercalifragilistic'
+      end
+    end
+
+    describe 'in an undefined environment' do
       let(:env) { 'undefined' }
 
-      it 'has the no "Foo"' do
+      it 'has the no parameter value' do
         expect(params['Foo']).to be_nil
       end
 


### PR DESCRIPTION
* Adds support for `AllowedPattern` in the `Environment` template parameter.

* Adds support for parameter files to have environment names that resemble regular expressions. If the parameter file doesn't have a key that matches the environment name exactly, then each of the top-level keys in the file will be interpreted as a regular expression and matched against the environment being deployed. The first match wins, so if multiple keys can match, then the result is undefined.

Related to Issue #16 .