### PR TITLE
Resolved #33, added exponential backoff for aws Throttling exceptions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,6 @@ Metrics/LineLength:
 Style/FileName:
   Exclude:
     - 'lib/aws-cft-tools.rb'
+
+Metrics/MethodLength:
+  Max: 15


### PR DESCRIPTION
Created an exponential backoff for retrying in situations where AWS is throttling/rate-limiting.  Per the AWS API, they will stop throttling fairly quickly, so continuing to retry until we succeed or fail for other reasons makes sense to me here.